### PR TITLE
Fix forwarding raddecs to webhook

### DIFF
--- a/lib/barnacleswebhook.js
+++ b/lib/barnacleswebhook.js
@@ -69,6 +69,18 @@ class BarnaclesWebhook {
       postViaHttp(data, options, self.printErrors);
     }
   }
+
+  /**
+   * Handle an outbound event
+   * @param {String} name The event name
+   * @param {Object} data The event data
+   * @returns 
+   */
+  handleEvent(name, data) {
+    if (name === 'raddec') {
+      return this.handleRaddec(data);
+    }
+  }
 }
 
 


### PR DESCRIPTION
I tried adding the barnacles-webhook module to Pareto Anywhere and noticed that the module did not send any raddec to an HTTP server. The `handleRaddec` function was never called.

I added the handleEvent function to handle an outbound event and call the `handleRaddec` function inside that function.